### PR TITLE
Implementa servicio de alertas por email usando Mailtrap.

### DIFF
--- a/Titans.Uptime.Api/Program.cs
+++ b/Titans.Uptime.Api/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using System.Net.Mail;
 using System.Text.Json.Serialization;
 using Titans.Uptime.Application.Interfaces;
 using Titans.Uptime.Application.Services;
@@ -25,6 +26,23 @@ builder.Services.AddScoped<ISystemService, SystemService>();
 builder.Services.AddScoped<IComponentService, ComponentService>();
 builder.Services.AddScoped<IUptimeCheckService, UptimeCheckService>();
 builder.Services.AddScoped<IUptimeEventService, UptimeEventService>();
+
+
+// Configuración SMTP
+var smtpHost = builder.Configuration["Smtp:Host"] ?? "sandbox.smtp.mailtrap.io";
+var smtpPort = int.Parse(builder.Configuration["Smtp:Port"] ?? "587");
+var smtpUser = builder.Configuration["Smtp:User"] ?? "30698baa9fb4ef";
+var smtpPass = builder.Configuration["Smtp:Pass"] ?? "8405f7aef7c022";
+var smtpFrom = builder.Configuration["Smtp:From"] ?? "titans@uptime.com";
+
+builder.Services.AddScoped<SmtpClient>(_ => new SmtpClient(smtpHost, smtpPort)
+{
+    Credentials = new System.Net.NetworkCredential(smtpUser, smtpPass),
+    EnableSsl = true
+});
+builder.Services.AddScoped<IEmailService>(provider =>
+    new EmailService(provider.GetRequiredService<SmtpClient>(), smtpFrom)
+);
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/Titans.Uptime.Api/appsettings.json
+++ b/Titans.Uptime.Api/appsettings.json
@@ -11,13 +11,13 @@
     "DefaultConnection": "Data Source=uptimemonitor.db"
   },
   "EmailSettings": {
-    "SmtpServer": "smtp.gmail.com",
+    "SmtpServer": "sandbox.smtp.mailtrap.io",
     "SmtpPort": 587,
     "EnableSsl": true,
-    "Username": "your-email@gmail.com",
-    "Password": "your-app-password",
-    "FromEmail": "your-email@gmail.com",
-    "FromName": "Uptime Monitor"
+    "Username": "30698baa9fb4ef",
+    "Password": "8405f7aef7c022",
+    "FromEmail": "titans@uptime.com",
+    "FromName": "Titans Uptime Monitor"
   },
   "MonitoringSettings": {
     "DefaultCheckInterval": 5,

--- a/Titans.Uptime.Application/Interfaces/IEmailService.cs
+++ b/Titans.Uptime.Application/Interfaces/IEmailService.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Titans.Uptime.Domain.Models;
+
+namespace Titans.Uptime.Application.Interfaces
+{
+    public interface IEmailService
+    {
+        Task SendAlertAsync(string[] recipients, string subject, string message);
+        Task SendDownAlertAsync(UptimeCheck uptimeCheck, UptimeEvent downEvent);
+        Task SendUpAlertAsync(UptimeCheck uptimeCheck, UptimeEvent upEvent);
+    }
+}

--- a/Titans.Uptime.Application/Services/EmailService.cs
+++ b/Titans.Uptime.Application/Services/EmailService.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Text;
+using System.Threading.Tasks;
+using Titans.Uptime.Application.Interfaces;
+using Titans.Uptime.Domain.Models;
+
+namespace Titans.Uptime.Application.Services
+{
+    public class EmailService : IEmailService
+    {
+        private readonly SmtpClient _smtpClient;
+        private readonly string _fromAddress;
+
+        public EmailService(SmtpClient smtpClient, string fromAddress)
+        {
+            _smtpClient = smtpClient;
+            _fromAddress = fromAddress;
+        }
+
+        public async Task SendAlertAsync(string[] recipients, string subject, string message)
+        {
+            if (recipients == null || recipients.Length == 0)
+                throw new ArgumentException("Debe proporcionar al menos un destinatario.");
+
+            using var mailMessage = new MailMessage()
+            {
+                From = new MailAddress(_fromAddress),
+                Subject = subject,
+                Body = message,
+                IsBodyHtml = false
+            };
+
+            foreach (var recipient in recipients.Where(r => !string.IsNullOrWhiteSpace(r)))
+            {
+                mailMessage.To.Add(recipient);
+            }
+
+            await _smtpClient.SendMailAsync(mailMessage);
+        }
+
+        public async Task SendDownAlertAsync(UptimeCheck uptimeCheck, UptimeEvent downEvent)
+        {
+            // Aquí defines el subject y el mensaje según tus reglas de monitoreo
+            var subject = $"ALERTA: {uptimeCheck.Name} está CAÍDO ({downEvent.StartTime:g})";
+            var message =
+                        $@"Hola,
+                        
+                        El servicio/endpoint '{uptimeCheck.Name}' ({uptimeCheck.CheckUrl}) está CAÍDO.
+                        
+                        Detalles:
+                        - Hora de caída: {downEvent.StartTime:g}
+                        - Error: {downEvent.ErrorMessage ?? "No especificado"}
+                        - Tipo de evento: {downEvent.EventType}
+                        - Id del UptimeCheck: {uptimeCheck.Id}
+                        
+                        Por favor, investigue la causa del incidente.
+                        
+                        -- Uptime Titans Monitor";
+
+            var recipients = GetAlertEmails(uptimeCheck);
+            await SendAlertAsync(recipients, subject, message);
+        }
+
+        public async Task SendUpAlertAsync(UptimeCheck uptimeCheck, UptimeEvent upEvent)
+        {
+            var subject = $"RECUPERADO: {uptimeCheck.Name} está ARRIBA ({upEvent.StartTime:g})";
+            var duration = upEvent.EndTime.HasValue && upEvent.StartTime != default(DateTime)
+                ? (upEvent.EndTime.Value - upEvent.StartTime).ToString(@"hh\:mm\:ss")
+                : "No disponible";
+
+            var message =
+                            $@"Hola,
+                            
+                            El servicio/endpoint '{uptimeCheck.Name}' ({uptimeCheck.CheckUrl}) se ha RECUPERADO.
+                            
+                            Detalles:
+                            - Hora de recuperación: {upEvent.StartTime:g}
+                            - Tiempo caído (aprox): {duration}
+                            - Id del UptimeCheck: {uptimeCheck.Id}
+                            
+                            Puede seguir monitoreando el estado en el dashboard.
+                            
+                            -- Uptime Titans Monitor";
+
+            var recipients = GetAlertEmails(uptimeCheck);
+            await SendAlertAsync(recipients, subject, message);
+        }
+
+        /// <summary>
+        /// Método auxiliar para obtener los emails de alerta del UptimeCheck.
+        /// Ajusta esto según cómo guardes los emails (separados por ; o , en la propiedad AlertEmails).
+        /// </summary>
+        private string[] GetAlertEmails(UptimeCheck uptimeCheck)
+        {
+            if (string.IsNullOrWhiteSpace(uptimeCheck.AlertEmails))
+                return Array.Empty<string>();
+            // Soporta separación por ',' o ';'
+            return uptimeCheck.AlertEmails
+                .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(e => e.Trim())
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
### Descripción

Este pull request implementa un servicio de alertas por email utilizando Mailtrap como proveedor SMTP. Ahora la aplicación puede enviar notificaciones automáticas cuando un servicio monitoreado cambia de estado (caído o recuperado).

#### Cambios principales:
- Se agrega la interfaz `IEmailService` y su implementación `EmailService`, encargada de enviar correos de alerta.
- Configuración de las credenciales SMTP y parámetros de email en `appsettings.json` y en la configuración de servicios de `Program.cs`.
- El servicio permite enviar dos tipos de alertas: cuando un servicio cae (`SendDownAlertAsync`) y cuando se recupera (`SendUpAlertAsync`).
- Los correos incluyen detalles como nombre del endpoint, URL, hora del incidente, error, tipo de evento y duración de la caída.
- Se utiliza Mailtrap como servidor SMTP para pruebas.

#### Archivos modificados/agregados:
- `Titans.Uptime.Api/Program.cs`: Configuración de dependencias y SMTP.
- `Titans.Uptime.Api/appsettings.json`: Parámetros para Mailtrap y datos del remitente.
- `Titans.Uptime.Application/Interfaces/IEmailService.cs`: Nueva interfaz para el servicio de email.
- `Titans.Uptime.Application/Services/EmailService.cs`: Implementación completa del servicio de email.