### PR TITLE
Se ha modificado el método GetAllAsync

### DIFF
--- a/Titans.Uptime.Application/Services/SystemService.cs
+++ b/Titans.Uptime.Application/Services/SystemService.cs
@@ -22,9 +22,11 @@ namespace Titans.Uptime.Application.Services
 
         public async Task<IEnumerable<SystemDto>> GetAllAsync()
         {
-            return await _context.Systems
-            .Include(s => s.Components)
-            .Select(s => new SystemDto
+            var systems = await _context.Systems
+                            .Include(s => s.Components)
+                            .ToListAsync();
+
+            return systems.Select(s => new SystemDto
             {
                 Id = s.Id,
                 Name = s.Name,
@@ -39,8 +41,7 @@ namespace Titans.Uptime.Application.Services
                     SystemName = s.Name,
                     CreatedAt = c.CreatedAt
                 }).ToList()
-            })
-            .ToListAsync();
+            });
         }
         public async Task<SystemDto?> GetByIdAsync(int id)
         {


### PR DESCRIPTION
This pull request updates the GetAllAsync method to first retrieve the full list of systems and their components using ToListAsync(), and then projects the results to SystemDto in memory. This change helps ensure all data is loaded before mapping, which can improve performance and reliability when dealing with related entities.